### PR TITLE
jwt bug fix

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,5 +1,8 @@
 import { Routes, Route } from 'react-router-dom';
 import { UserProvider } from './common/Context/UserContext';
+import './common/Api/Api'
+import './common/Api/RefreshApi';
+import './common/Api/ApiService'
 import RegisterPage from './user/Page/RegisterPage';
 import LoginPage from './user/Page/LoginPage';
 import UserInfoPage from './user/Page/UserInfoPage';

--- a/frontend/src/common/Api/Api.jsx
+++ b/frontend/src/common/Api/Api.jsx
@@ -15,11 +15,7 @@ export const API_ENDPOINTS = {
   }
 }
 
-export const createHeaders = () => {
-  const token = localStorage.getItem('accessToken');
-  return {
-    'Content-Type': 'application/json',
-    ...(token ? { Authorization: `Bearer ${token}` } : {}),
-  };
-};
+export const createHeaders = () => ({
+  'Content-Type': 'application/json',
+});
 

--- a/frontend/src/common/Api/ApiService.jsx
+++ b/frontend/src/common/Api/ApiService.jsx
@@ -1,24 +1,41 @@
 import React from 'react';
-import RefreshApi from '../../common/Api/RefreshApi';
-import { API_ENDPOINTS, createHeaders } from '../../common/Api/Api';
+import RefreshApi from './RefreshApi'
+import { API_ENDPOINTS, createHeaders } from './Api';
 import axios from 'axios';
-
-const header = () => ({ headers: createHeaders() });
 
 const ApiService = {
   
     userService:{
-    //로그인이나 회원 가입 과정에는 토큰 불필요
-    login: (dto) => axios.post(API_ENDPOINTS.auth.login, dto, { withCredentials: true }),
-    register: (dto) => axios.post(API_ENDPOINTS.auth.register, dto, { withCredentials: true }),
+    login: (dto) => axios.post(API_ENDPOINTS.auth.login, dto, {
+       withCredentials: true, 
+    }),
+    register: (dto) => axios.post(API_ENDPOINTS.auth.register, dto, { 
+      withCredentials: true, 
+    }),
 
-    delete: (loginId,password) => RefreshApi.post(API_ENDPOINTS.auth.delete, { LoginId: loginId, Password: password }, 
-      ...header(),),
-    update: (dto) => RefreshApi.put(API_ENDPOINTS.auth.update, dto, header(), ),
-    logout: ()=> RefreshApi.post(API_ENDPOINTS.auth.logout, null, header(), ), 
-    info: () => RefreshApi.get(API_ENDPOINTS.auth.info, header()),
-    detail: (userLoginId) =>RefreshApi.get(API_ENDPOINTS.auth.detail, 
-      { params: { userLoginId }, ...header() }) 
+    delete: (loginId,password) => RefreshApi.post(API_ENDPOINTS.auth.delete, 
+    { LoginId: loginId, Password: password }, 
+    {
+      headers: createHeaders(),
+      withCredentials: true,
+    }),
+    update: (dto) => RefreshApi.put(API_ENDPOINTS.auth.update, dto, {
+      headers: createHeaders(),
+      withCredentials: true,
+    }),
+    logout: ()=> RefreshApi.post(API_ENDPOINTS.auth.logout, null, {
+      headers: createHeaders(),
+      withCredentials: true,
+    }), 
+    info: () => RefreshApi.get(API_ENDPOINTS.auth.info, {
+      headers: createHeaders(),
+      withCredentials: true,
+    }),
+    detail: (userLoginId) =>RefreshApi.get(API_ENDPOINTS.auth.detail, { 
+      params: { userLoginId }, 
+      headers: createHeaders(),
+      withCredentials: true, 
+    }), 
   },
 
   businessService:{

--- a/frontend/src/common/Api/RefreshApi.jsx
+++ b/frontend/src/common/Api/RefreshApi.jsx
@@ -6,33 +6,15 @@ const RefreshApi = axios.create({
     withCredentials: true,
 });
 
-
 RefreshApi.interceptors.response.use(
-  (response) => response,
-  async (error) => {
-
-    const originalRequest = error.config;
-
-    if (error.response && error.response.status === 401 && !originalRequest._retry) {
-      originalRequest._retry = true;
-      try {
-        const storedRefreshToken = localStorage.getItem('refreshToken');
-        const refreshResponse = await axios.post(
-          API_ENDPOINTS.auth.refresh,
-          { refreshToken: storedRefreshToken }, 
-          { withCredentials: true }
-        );
-
-        const newAccessToken = refreshResponse.data.accessToken;
-        localStorage.setItem('accessToken', newAccessToken);
-
-        return RefreshApi(originalRequest);
-      } catch (refreshError) {
-        return Promise.reject(refreshError);
-      }
+  (response) =>  response,
+  (error) => {
+    if(error.response?.status === 401){
+      window.location.href = '/user/login';
     }
     return Promise.reject(error);
   }
+
 );
 
 export default RefreshApi;

--- a/frontend/src/common/Context/UserContext.jsx
+++ b/frontend/src/common/Context/UserContext.jsx
@@ -12,7 +12,7 @@ const initialUser = {
   point: 0,
   createAt: '',
   updateAt: '',
-
+  role: null,
   petBusinessDTO: {
     id:'',
     businessName:'',
@@ -29,7 +29,10 @@ const initialUser = {
     petBusinessTypeName: '',
     petBusinessTypeId: '',
   },
-  role: null,
+  petDTOList: [],
+  bookmarkDTOList: [],
+  qnaPostDTOList: [],
+  qnaAnswerDTOList: [],
 };
 
 const mapUserDto= (dto) => {
@@ -94,23 +97,25 @@ export const useUser = () => useContext(UserContext);
 
 export const UserProvider = ({ children }) => {
   const [user, dispatch] = useReducer(userReducer, initialUser);
+
+  const updateUser = (newData) => {
+    const updatedUser = { ...user, ...newData };
+    dispatch({ type: 'SET_USER', payload: updatedUser });
+    sessionStorage.setItem('user', JSON.stringify(updatedUser));
+  };
   
+  const resetUser = () => {
+    dispatch({ type: 'RESET_USER' });
+    sessionStorage.removeItem('user');
+  };
+
   useEffect(() => {
-    const storedUser = localStorage.getItem('user');
+    const storedUser = sessionStorage.getItem('user');
     if (storedUser) {
       dispatch({ type: 'SET_USER', payload: JSON.parse(storedUser) });
     }
   }, []);
 
-  const updateUser = (newData) => {
-    dispatch({ type: 'SET_USER', payload: newData });
-    localStorage.setItem('user', JSON.stringify({ ...user, ...newData }));
-  };
-  
-  const resetUser = () => {
-    dispatch({ type: 'RESET_USER' });
-    localStorage.removeItem('user');
-  };
   
   return (
     <UserContext.Provider value={{ user, mapUserDto, updateUser, resetUser }}>

--- a/frontend/src/user/Form/DeleteForm.jsx
+++ b/frontend/src/user/Form/DeleteForm.jsx
@@ -1,12 +1,11 @@
 import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useUser } from '../../common/Context/UserContext';
-import { API_ENDPOINTS, createHeaders   } from '../../common/Api/Api';
-import RefreshApi from '../../common/Api/RefreshApi';
 import '../../common/Css/common.css';
 import Button from '../../common/Ui/Button';
 import TextInput from '../../common/Ui/TextInput';
 import PasswordInput from '../../common/Ui/PasswordInput';
+import ApiService from '../../common/Api/ApiService';
 
 function UserDeleteForm(props){
   
@@ -19,17 +18,7 @@ function UserDeleteForm(props){
     e.preventDefault();
 
     try{
-      const response = await RefreshApi.post(
-        API_ENDPOINTS.auth.delete,
-        { 
-          LoginId: userid, 
-          Password: userpass,
-        },
-        { 
-          withCredentials: true, 
-          headers: createHeaders(),
-        }
-    );
+      const response = await ApiService.userService.delete(userid,userpass);
 
       if(response.data.result){
         alert('회원 탈퇴가 완료되었습니다.');

--- a/frontend/src/user/Form/LoginForm.jsx
+++ b/frontend/src/user/Form/LoginForm.jsx
@@ -1,8 +1,7 @@
 import React, {useState} from 'react';
 import { useNavigate } from 'react-router-dom';
-import axios from 'axios';
-import { API_ENDPOINTS, createHeaders   } from '../../common/Api/Api';
-import RefreshApi from '../../common/Api/RefreshApi';
+import { API_ENDPOINTS } from '../../common/Api/Api';
+import ApiService from '../../common/Api/ApiService';
 import TextInput from '../../common/Ui/TextInput';
 import PasswordInput from '../../common/Ui/PasswordInput';
 import Button from '../../common/Ui/Button';
@@ -19,12 +18,11 @@ function LoginForm(props){
   const handleLogin = async (e)=>{
     e.preventDefault();
     try{
-      const response = await axios.post(API_ENDPOINTS.auth.login,
-        { username, password },
-        { withCredentials: true }
-      );
-      if(response.data.authenticated){
+      const response = await ApiService.userService.login({username, password});
+      const  { authenticated, LoginUser } = response.data;
+      if(authenticated){
         console.log('login success');
+        updateUser(LoginUser);
         navigate('/user/info');
       }else{
         console.log('login fail');

--- a/frontend/src/user/component/LogoutButton.jsx
+++ b/frontend/src/user/component/LogoutButton.jsx
@@ -1,10 +1,9 @@
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useUser } from '../../common/Context/UserContext';
-import { API_ENDPOINTS, createHeaders   } from '../../common/Api/Api';
-import RefreshApi from '../../common/Api/RefreshApi';
 import '../../common/Css/common.css';
 import Button from '../../common/Ui/Button';
+import ApiService from '../../common/Api/ApiService';
 
 function LogoutButton(props){
     
@@ -12,9 +11,7 @@ function LogoutButton(props){
     const { resetUser } = useUser();
     const handleLogout = async ()=>{
       try{
-        const response= await RefreshApi.post(API_ENDPOINTS.auth.logout,{
-          headers: createHeaders(),
-        });
+        const response = await ApiService.userService.logout();
   
         if(response.data.result){
           alert('로그아웃 되었습니다.');

--- a/src/main/java/com/petservice/main/user/database/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/petservice/main/user/database/repository/RefreshTokenRepository.java
@@ -13,7 +13,7 @@ public interface RefreshTokenRepository extends JpaRepository<RefreshToken,Long>
 
   Optional<RefreshToken> findByToken(String token);
 
-  Optional<RefreshToken> findByUser(User user);
+  RefreshToken findByUser_Id(Long User_id);
 
   @Modifying
   int deleteByUser(User user);

--- a/src/main/java/com/petservice/main/user/jwt/JwtFilter.java
+++ b/src/main/java/com/petservice/main/user/jwt/JwtFilter.java
@@ -1,6 +1,9 @@
 package com.petservice.main.user.jwt;
 
 import com.petservice.main.user.database.dto.CustomUserDetails;
+import com.petservice.main.user.database.entity.RefreshToken;
+import com.petservice.main.user.database.entity.User;
+import com.petservice.main.user.service.Interface.RefreshTokenServiceInterface;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.Cookie;
@@ -8,6 +11,8 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -15,6 +20,7 @@ import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
+import java.util.Optional;
 
 //JWT 토큰의 유효성 검사
 @Slf4j
@@ -22,10 +28,14 @@ import java.io.IOException;
 public class JwtFilter extends OncePerRequestFilter {
 
   private final JwtService jwtService;
+  private final RefreshTokenServiceInterface refreshTokenService;
+  private static final long ACCESS_TOKEN_MAX_AGE_SECONDS = 15 * 60L;
+
   private static final String[] WITHOUT_TOKEN_URL={
+      "/user/login",
+      "/user/register",
       "/api/user/login",
       "/api/user/register",
-      "/api/user/refresh"
   };
 
   @Override
@@ -34,57 +44,91 @@ public class JwtFilter extends OncePerRequestFilter {
 
     try {
       for (String url : WITHOUT_TOKEN_URL) {
-        if (request.getRequestURI().equals(url)) {
+        if (request.getRequestURI().compareTo(url) == 0) {
           filterChain.doFilter(request, response);
           return;
         }
       }
 
-      String authorization = null;
-      Cookie[] cookies = request.getCookies();
-      if (cookies != null) {
-        for (Cookie cookie : cookies) {
-          if ("accessToken".equals(cookie.getName())) {
-            authorization = cookie.getValue();
-            log.info("Found access token in cookie.");
-            break;
+      String accessToken  = extractCookie(request, "accessToken");;
+
+      if(accessToken ==null) {
+        String hdr  = request.getHeader("Authorization");
+          if (StringUtils.hasText(hdr ) && hdr.startsWith("Bearer ")) {
+            accessToken = accessToken.substring(7);
           }
+      }
+
+      if (accessToken == null) {
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        return;
+      }
+
+      if(jwtService.isExpired(accessToken)){
+        log.info("Access token expired; attempting refresh inside filter");
+
+        String refreshToken = extractCookie(request, "refreshToken");
+        if (refreshToken == null) {
+          response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+          return;
         }
+
+        Optional<RefreshToken> findRefreshToken = refreshTokenService.findByToken(refreshToken);
+        if (findRefreshToken.isEmpty() || refreshTokenService.verifyExpiration(findRefreshToken.get()) == null) {
+          response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
+          return;
+        }
+
+        User user = findRefreshToken.get().getUser();
+        String newAccessToken =
+            jwtService.createJwt(user.getUserLoginId(), user.getRole().name(), user.getName(),
+                ACCESS_TOKEN_MAX_AGE_SECONDS * 1000, "ACCESS");
+
+        ResponseCookie cookie = ResponseCookie.from("accessToken", newAccessToken)
+            .httpOnly(true)
+            .secure(true)
+            .path("/")
+            //.maxAge(ACCESS_TOKEN_MAX_AGE_SECONDS)
+            .sameSite("None")
+            .build();
+        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+
+        accessToken = newAccessToken;
       }
-      if(authorization==null) {
-        String accessToken = request.getHeader("Authorization");
-          if (StringUtils.hasText(accessToken) && accessToken.startsWith("Bearer ")) {
-            authorization = accessToken.substring(7);
-          }
-      }
-      if (authorization == null) {
-        log.info("No token found in request");
-        filterChain.doFilter(request, response);
+
+      if(!jwtService.isExpired(accessToken)) {
+        String LoginId = jwtService.getLoginId(accessToken);
+        String role = jwtService.getRole(accessToken);
+        String Username = jwtService.getUsername(accessToken);
+
+        CustomUserDetails customUserDetails = new CustomUserDetails(LoginId, Username, role);
+
+        Authentication authentication =
+            new UsernamePasswordAuthenticationToken(customUserDetails, null,
+                customUserDetails.getAuthorities());
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+        log.info("token auth");
+
+      }else{
+        response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
+        log.info("new token fail");
         return;
       }
-
-      String token = authorization;
-
-      if (jwtService.isExpired(token)) {
-        log.info("Token is expired");
-        filterChain.doFilter(request, response);
-        return;
-      }
-      //로그인 아이디
-      String LoginId = jwtService.getLoginId(token);
-      String role=jwtService.getRole(token);
-      String Username=jwtService.getUsername(token);
-
-      CustomUserDetails customUserDetails = new CustomUserDetails(LoginId,Username,role);
-
-      Authentication authentication = new UsernamePasswordAuthenticationToken(customUserDetails, null,
-              customUserDetails.getAuthorities());
-      SecurityContextHolder.getContext().setAuthentication(authentication);
     }catch (Exception e){
       log.error("Error JWT {}",e.getMessage());
     }
+
     filterChain.doFilter(request, response);
 
   }
 
+  private String extractCookie(HttpServletRequest req, String name) {
+    if (req.getCookies() == null) return null;
+    for (Cookie c : req.getCookies()) {
+      if (name.equals(c.getName())) {
+        return c.getValue();
+      }
+    }
+    return null;
+  }
 }

--- a/src/main/java/com/petservice/main/user/jwt/JwtService.java
+++ b/src/main/java/com/petservice/main/user/jwt/JwtService.java
@@ -1,7 +1,9 @@
 package com.petservice.main.user.jwt;
 
+import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jwts;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.oauth2.jwt.JwtException;
 import org.springframework.stereotype.Component;
 
 import javax.crypto.SecretKey;
@@ -46,12 +48,22 @@ public class JwtService {
   }
 
   public Boolean isExpired(String token) {
-    return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload()
-        .getExpiration().before(new Date());
+    try {
+      Jwts.parser()
+          .verifyWith(secretKey)
+          .build()
+          .parseSignedClaims(token)
+          .getPayload();
+      return false;
+    } catch (ExpiredJwtException e) {
+      return true;
+    } catch (JwtException e) {
+      return true;
+    }
   }
 
   public String createAccessToken(String LoginId, String UserName, String role) {
-    return createJwt(LoginId, role, UserName, accessTokenDurationMs,"ACCESS");
+    return createJwt(LoginId, role, UserName, accessTokenDurationMs, "ACCESS");
   }
 
   public String createRefreshToken(String LoginId, String UserName, String role) {

--- a/src/main/java/com/petservice/main/user/service/RefreshTokenService.java
+++ b/src/main/java/com/petservice/main/user/service/RefreshTokenService.java
@@ -35,11 +35,10 @@ public class RefreshTokenService implements RefreshTokenServiceInterface {
     User user=userRepository.findByUserLoginId(userLoginId)
         .orElseThrow(() -> new RuntimeException("User not found with LoginId: " + userLoginId));
 
-    Optional<RefreshToken> existingToken = refreshTokenRepository.findByUser(user);
-    if(existingToken.isPresent()){
-      RefreshToken refreshToken = existingToken.get();
-      refreshToken.setExpiryDate(Instant.now().plusMillis(refreshTokenDurationMs));
-      return refreshTokenRepository.save(refreshToken);
+    RefreshToken existingToken = refreshTokenRepository.findByUser_Id(user.getId());
+    if(existingToken != null){
+      existingToken.setExpiryDate(Instant.now().plusMillis(refreshTokenDurationMs));
+      return refreshTokenRepository.save(existingToken);
     }
 
     RefreshToken refreshToken=new RefreshToken();


### PR DESCRIPTION
## 설명
정상적으로 jwt access token의 만료 되면 refresh token의 만료 여부를 검사하고 refresh token이 유효하면 새로운 access token을 발급하도록 버그 수정, 프론트 엔드 api 실행 부분(로그인, 회원 탈퇴 컴포넌트 등) 단순화, api 정의 부분 가독성 개선, localstorage에 토큰 저장안하도록 수정

추후 커스텀 오류 관련 로직 작성 예정

## 작성 타입
- [x] 버그 수정
- [x] 새로운 기능 추가
- [ ] 설명 수정
- [x] 코드 리팩토링(경로 변경, 성능 최적화)

## 체크사항
- [x] 내가 작성한 코드를 직접 테스트를 하였습니다.
- [x] 내가 작성한 코드에 대해서 주변에 미치는 영향을 최소화 하였습니다.
- [x] 깔끔히 코드를 작성 하였으며, 프로젝트 내 테스트 경로 외의 테스트 코드를 모두 지운 것을 확인하였습니다.
- [ ] 코드가 이해하기 쉽게 작성되었는지 확인하였습니다.
- [x] 코드 내 민감한 정보가 없는 것을 확인하였습니다.
- [ ] 하드코딩을 모두 지운 것을 확인하였습니다.

## 특이 사항
코드 작성하면서 문제되는 부분이나, 불편한 점에 대해 적어주세요!!
