### PR TITLE
실제 사업자 api에 맞게 코드 변경 및 프론트 엔드 구현

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -7,6 +7,7 @@
     <title>Vite + React</title>
   </head>
   <body>
+    <div id="modal-root"></div>
     <div id="root"></div>
     <script type="module" src="/src/main.jsx"></script>
   </body>

--- a/frontend/src/businesstype/Component/BusinessType.jsx
+++ b/frontend/src/businesstype/Component/BusinessType.jsx
@@ -1,0 +1,31 @@
+import React from "react";
+import CusomP from '../../common/Ui/CusomP';
+import CustomLabel from "../../common/Ui/CustomLabel";
+function BusinessType(props){
+  
+  const {id, sectorCode, typeCode, typeName, description} = props;
+  return (
+    <>
+    <div className="BusinessType">
+
+      <CustomLabel classtext={'BusinessTypeLabel'} title={'아이디'} for={'BusinessTypeInfo'}/>
+      <CusomP classtext={'BusinessTypeInfo'} title={id}/>
+      
+      <CustomLabel classtext={'BusinessTypeLabel'} title={'타입 이름'} for={'BusinessTypeInfo'}/>
+      <CusomP classtext={'BusinessTypeInfo'} title={typeName}/>
+
+      <CustomLabel classtext={'BusinessTypeLabel'} title={'섹터 코드'} for={'BusinessTypeInfo'}/>
+      <CusomP classtext={'BusinessTypeInfo'} title={sectorCode}/>
+
+      <CustomLabel classtext={'BusinessTypeLabel'} title={'타입 코드'} for={'BusinessTypeInfo'}/>
+      <CusomP classtext={'BusinessTypeInfo'} title={typeCode}/>
+
+      <CustomLabel classtext={'BusinessTypeLabel'} title={'타입 설명'} for={'BusinessTypeInfo'}/>
+      <CusomP classtext={'BusinessTypeInfo'} title={description}/>
+    
+    </div>
+    </>
+  );
+}
+
+export default BusinessType;

--- a/frontend/src/businesstype/Component/BusinessTypeDeleteButton.jsx
+++ b/frontend/src/businesstype/Component/BusinessTypeDeleteButton.jsx
@@ -1,0 +1,55 @@
+import React, { useState } from "react";
+import Button from '../../common/Ui/Button';
+import Modal from '../../common/Ui/Modal';
+import CusomP from '../../common/Ui/CusomP';
+import ApiService from "../../common/Api/ApiService";
+
+function BusinessTypeDeleteButton(props){
+  const {type_id,businesstype}=props;
+  const [isModalOpen, setModalOpen] = useState(false);
+
+  const handleTypeDelete= async (type_id,businesstype) =>{
+    const response= await ApiService.businessTypeService.delete(type_id,businesstype);
+    const result = response.data;
+
+    if(result.result){
+      const deletetype=result.deleteType;
+      alert(result.message+'\n 새로고침하면 사라집니다!!'
+        +'\n 삭제된 타입 정보: \n'
+        + '아이디: '+ deletetype.id
+        + '타입 이름: '+ deletetype.typeName
+        + '섹터 코드: '+ deletetype.sectorCode
+        + '타입 코드: '+ deletetype.typeCode
+        + '타입 설명: '+ deletetype.description);
+        setModalOpen(false);
+
+    }else{
+        alert(result.message);
+        setModalOpen(false);
+    }
+
+  }
+  return (
+    <>
+    <div className="BusinessTypeComponent">
+      <Button
+        classtext={'BusinessTypeButton'}
+        type="button"
+        title={'사업 타입 삭제'}
+        onClick={()=>setModalOpen(true)}
+      />
+      <Modal isOpen={isModalOpen} onClose={() => setModalOpen(false)}>
+        <CusomP classtext={'alertText'} title={'정말로 삭제하겠습니까?'}/>
+        <Button
+          classtext={'BusinessTypeButton'}
+          type="button"
+          title={'타입 삭제(복구 불가)'}
+          onClick={handleTypeDelete(type_id,businesstype)}
+        />
+      </Modal>
+    </div>
+    </>
+  );
+}
+
+export default BusinessTypeDeleteButton;

--- a/frontend/src/businesstype/Component/BusinessTypeManageList.jsx
+++ b/frontend/src/businesstype/Component/BusinessTypeManageList.jsx
@@ -2,9 +2,13 @@ import React, { useEffect, useState } from "react";
 import ApiService from "../../common/Api/ApiService";
 import BusinessType from "./BusinessType";
 import CusomP from "../../common/Ui/CusomP";
+import Modal from "../../common/Ui/Modal";
+import Button from "../../common/Ui/Button";
+import BusinessTypeUpdateForm from "../Form/BusinessTypeUpdateForm";
 
-function BusinessTypeList(props){
+function BusinessManageTypeList(props){
   const [typelist,setTypelist]= useState([]);
+  const [isModalOpen,setModalOpen]=useState(false);
 
   useEffect(()=>{
     const fetchTypes = async () => {
@@ -24,9 +28,10 @@ function BusinessTypeList(props){
       <div>
       {
         typelist !== null ?  
-        <div className="BusinessTypeList">
+        <div className="BusinessTypeManageList">
         {typelist.map((type) => 
         <>
+          <div className="BusinessTypeManage">
             <BusinessType 
               key={type.id} 
               id={type.id} 
@@ -35,6 +40,25 @@ function BusinessTypeList(props){
               typeCode={type.typeCode}
               description={type.description}
             />
+            <div className="buttonset">
+                <BusinessTypeDeleteButton type_id={type.id} businesstype={type}/>
+                <Button 
+                  classtext={'BusinessTypeButton'} 
+                  type="button" 
+                  title={'타입 수정'} 
+                  onClick={setModalOpen(!isModalOpen)}
+                />
+                <Modal isOpen={isModalOpen} onClose={() => setModalOpen(false)}>
+                  <BusinessTypeUpdateForm 
+                    exId={type.id}
+                    exTypename={type.typeName}
+                    exSectorCode={type.sectorCode}
+                    exTypeCode={type.typeCode}
+                    exDescription={type.description}
+                  />
+                </Modal>
+            </div>
+          </div>
         </>
         )}
         </div>
@@ -47,4 +71,4 @@ function BusinessTypeList(props){
   );
 }
 
-export default BusinessTypeList;
+export default BusinessManageTypeList;

--- a/frontend/src/businesstype/Form/BusinessTypeRegisterForm.jsx
+++ b/frontend/src/businesstype/Form/BusinessTypeRegisterForm.jsx
@@ -1,0 +1,108 @@
+import React, { useState } from "react";
+import CusomP from '../../common/Ui/CusomP';
+import CustomLabel from "../../common/Ui/CustomLabel";
+import TextInput from "../../common/Ui/TextInput";
+import Button from "../../common/Ui/Button";
+import ApiService from "../../common/Api/ApiService";
+
+function BusinessTypeRegisterForm(props){
+  
+  const [typename,setTypename]= useState('');
+  const [description,setDescription]= useState('');
+  const [sectorCode,setSectorCode]= useState('');
+  const [typeCode,setTypeCode]= useState('');
+
+  const handleTypeSubmit = async(e) => {
+    e.preventDefault();
+    const typedto={
+      id: null,
+      typeName: typename,
+      sectorCode: sectorCode,
+      typeCode: typeCode,
+      description: description,
+      petBusinessDTOList: []
+    }
+    const response = await ApiService.businessTypeService.register(typedto);
+    const result=response.data;
+    if(result.result){
+      const newtype=result.type;
+
+      alert(result.message
+        + '\n 새롭게 추가된 타입 정보'
+        + '\n 타입 아이디: '+ newtype.id
+        + '\n 타입 이름: '+ newtype.typeName
+        + '\n 섹터 코드: '+ newtype.sectorCode
+        + '\n 타입 코드: '+ newtype.typeCode
+        + '\n 타입 설명: '+ newtype.description);
+      setModalOpen(false);
+
+    }else{
+      alert(result.message);
+    }
+  }
+  
+  return (
+    <>
+      <form className="BusinessTypeForm" onSubmit={handleTypeSubmit}>
+        
+        <CusomP
+          classtext={'alertText'}
+          title={'타입 추가 창'}
+        />
+        <CusomP
+          classtext={'alertText'}
+          title={'별도의 타입을 추가해보세요!'}
+        />
+
+        <CustomLabel classtetxt={'BusinessTypeLabel'} title={'타입 이름:'} for={'UserUpdateInfo'}/>
+        <TextInput 
+          classtext="BusinessTypeInput"
+          name="typeName" 
+          value={typename} 
+          placeholderText="새로운 사업자 타입 이름을 입력하세요" 
+          onChange={(e)=>setTypename(e.target.value)}
+        />
+
+        <CustomLabel classtetxt={'BusinessTypeLabel'} title={'섹터 코드:'} for={'UserUpdateInfo'}/>
+        <TextInput 
+          classtext="BusinessTypeInput"
+          name="sectorCode" 
+          value={sectorCode} 
+          placeholderText="새로운 섹터 코드를 입력하세요" 
+          onChange={(e)=>setSectorCode(e.target.value)}
+        />
+        
+        <CustomLabel classtetxt={'BusinessTypeLabel'} title={'타입 코드:'} for={'UserUpdateInfo'}/>
+        <TextInput 
+          classtext="BusinessTypeInput"
+          name="typeCode" 
+          value={typeCode} 
+          placeholderText="새로운 타입 코드을 입력하세요" 
+          onChange={(e)=>setTypeCode(e.target.value)}
+        />
+
+        <CustomLabel classtetxt={'BusinessTypeLabel'} title={'타입 설명:'} for={'UserUpdateInfo'}/>
+        <textarea className="" name="" value={description} 
+        placeholder="사업자 타입에 대한 설명을 작성해 주세요." onChange={(e)=>setDescription(e.target.value)}/>
+
+        <Button 
+          classtext={'BusinessTypeButton'}
+          type="button"
+          title={'사업 타입 추가'}
+          onClick={()=>setModalOpen(true)}
+        />
+
+        <Modal isOpen={isModalOpen} onClose={() => setModalOpen(false)}>
+          <CusomP classtext={'alertText'} title={'정말로 추가 하겠습니까?'}/>
+          <Button
+            classtext={'BusinessTypeButton'}
+            type="submit"
+            title={'타입 추가'}
+          />
+        </Modal>
+      </form>
+    </>
+  );
+}
+
+export default BusinessTypeRegisterForm;

--- a/frontend/src/businesstype/Form/BusinessTypeUpdateForm.jsx
+++ b/frontend/src/businesstype/Form/BusinessTypeUpdateForm.jsx
@@ -1,0 +1,103 @@
+import React, { useState } from "react";
+import CusomP from '../../common/Ui/CusomP';
+import CustomLabel from "../../common/Ui/CustomLabel";
+import TextInput from "../../common/Ui/TextInput";
+import Button from "../../common/Ui/Button";
+import ApiService from "../../common/Api/ApiService";
+
+function BusinessTypeUpdateForm(props){
+  const {exId,exTypename,exDescription,exSectorCode,exTypeCode}=props;
+
+  const [isModalOpen,setModalOpen]=useState(false);
+  const [typename,setTypename]= useState(exTypename);
+  const [description,setDescription]= useState(exDescription);
+
+  const handleTypeSubmit = async(e) => {
+    e.preventDefault();
+    const typedto={
+      id: exId,
+      typeName: typename,
+      sectorCode: exSectorCode,
+      typeCode: exTypeCode,
+      description: description,
+      petBusinessDTOList: []
+    }
+
+    const response = await ApiService.businessTypeService.update(typedto);
+    const result=response.data;
+    if(result.result){
+      const newtype=result.type;
+
+      alert(result.message
+        + '\n 새롭게 수정된 타입 정보'
+        + '\n 타입 아이디: '+ newtype.id
+        + '\n 타입 이름: '+ newtype.typeName
+        + '\n 섹터 코드: '+ newtype.sectorCode
+        + '\n 타입 코드: '+ newtype.typeCode
+        + '\n 타입 설명: '+ newtype.description);
+      setModalOpen(false);
+
+    }else{
+      alert(result.message);
+    }
+  }
+  
+  return (
+    <>
+      <form className="BusinessTypeForm" onSubmit={handleTypeSubmit}>
+        
+        <CusomP
+          classtext={'alertText'}
+          title={'타입 수정 창'}
+        />
+        <CusomP
+          classtext={'alertText'}
+          title={'섹터 코드와 타입 코드는 수정이 불가능합니다.'}
+        />
+
+        <CustomLabel classtetxt={'BusinessTypeLabel'} title={'타입 이름:'} for={'UserUpdateInfo'}/>
+        <TextInput 
+          classtext="BusinessTypeInput"
+          name="typeName" 
+          value={typename} 
+          placeholderText="새로운 사업자 타입 이름을 입력하세요" 
+          onChange={(e)=>setTypename(e.target.value)}
+        />
+
+        <CustomLabel classtetxt={'BusinessTypeLabel'} title={'섹터 코드:'} for={'BusinessTypeInfo'}/>
+        <CusomP
+          classtext={'BusinessTypeInfo'}
+          title={exSectorCode}
+        />
+        
+        <CustomLabel classtetxt={'BusinessTypeLabel'} title={'타입 코드:'} for={'BusinessTypeInfo'}/>
+        <CusomP
+          classtext={'BusinessTypeInfo'}
+          title={exTypeCode}
+        />
+
+        <CustomLabel classtetxt={'BusinessTypeLabel'} title={'타입 설명:'} for={'UserUpdateInfo'}/>
+        <textarea className="" name="" value={description} 
+        placeholder="사업자 타입에 대한 설명을 작성해 주세요." onChange={(e)=>setDescription(e.target.value)}/>
+
+        <Button 
+          classtext={'BusinessTypeButton'}
+          type="button"
+          title={'사업 타입 수정'}
+          onClick={()=>setModalOpen(true)}
+        />
+
+        <Modal isOpen={isModalOpen} onClose={() => setModalOpen(false)}>
+          <CusomP classtext={'alertText'} title={'정말로 수정 하시겠습니까?'}/>
+          <Button
+            classtext={'BusinessTypeButton'}
+            type="submit"
+            title={'타입 수정'}
+          />
+        </Modal>
+      </form>
+    </>
+  );
+}
+
+export default BusinessTypeUpdateForm;

--- a/frontend/src/common/Ui/Modal.jsx
+++ b/frontend/src/common/Ui/Modal.jsx
@@ -14,8 +14,8 @@ function Modal(props){
         <button className="modal-close" onClick={onClose}>×</button>
         {children}
       </div>
-    </>
-    
+    </>,
+    document.getElementById('modal-root') 
   );
 }
 

--- a/src/main/java/com/petservice/main/business/database/dto/PetBusinessTypeDTO.java
+++ b/src/main/java/com/petservice/main/business/database/dto/PetBusinessTypeDTO.java
@@ -11,5 +11,7 @@ public class PetBusinessTypeDTO {
   private Long id;
   private String typeName;
   private String description;
+  private String sectorCode;
+  private String typeCode;
   private List<PetBusinessDTO> petBusinessDTOList = new ArrayList<>();
 }

--- a/src/main/java/com/petservice/main/business/database/entity/PetBusinessType.java
+++ b/src/main/java/com/petservice/main/business/database/entity/PetBusinessType.java
@@ -20,6 +20,12 @@ public class PetBusinessType {
   @Column(name = "type_name", unique = true)
   private String typeName;
 
+  @Column(name="sector_code")
+  private String sectorCode;
+
+  @Column(name="type_code")
+  private String typeCode;
+
   @Column(columnDefinition = "TEXT")
   private String description;
 

--- a/src/main/java/com/petservice/main/business/database/mapper/PetBusinessTypeMapper.java
+++ b/src/main/java/com/petservice/main/business/database/mapper/PetBusinessTypeMapper.java
@@ -16,6 +16,8 @@ public class PetBusinessTypeMapper {
     PetBusinessType petBusinessType=new PetBusinessType();
     petBusinessType.setId(petBusinessTypeDTO.getId());
     petBusinessType.setTypeName(petBusinessTypeDTO.getTypeName());
+    petBusinessType.setSectorCode(petBusinessTypeDTO.getSectorCode());
+    petBusinessType.setTypeCode(petBusinessTypeDTO.getTypeCode());
     petBusinessType.setDescription(petBusinessTypeDTO.getDescription());
     if(petBusinessTypeDTO.getPetBusinessDTOList()!=null) {
       petBusinessType.setPetBusinessList(
@@ -31,6 +33,8 @@ public class PetBusinessTypeMapper {
     PetBusinessTypeDTO petBusinessTypeDTO =new PetBusinessTypeDTO();
     petBusinessTypeDTO.setId(petBusinessType.getId());
     petBusinessTypeDTO.setTypeName(petBusinessType.getTypeName());
+    petBusinessTypeDTO.setSectorCode(petBusinessType.getSectorCode());
+    petBusinessTypeDTO.setTypeCode(petBusinessType.getTypeCode());
     petBusinessTypeDTO.setDescription(petBusinessType.getDescription());
     if(petBusinessType.getPetBusinessList()!=null) {
       petBusinessTypeDTO.setPetBusinessDTOList(
@@ -45,6 +49,8 @@ public class PetBusinessTypeMapper {
     PetBusinessTypeDTO petBusinessTypeDTO =new PetBusinessTypeDTO();
     petBusinessTypeDTO.setId(petBusinessType.getId());
     petBusinessTypeDTO.setTypeName(petBusinessType.getTypeName());
+    petBusinessTypeDTO.setSectorCode(petBusinessType.getSectorCode());
+    petBusinessTypeDTO.setTypeCode(petBusinessType.getTypeCode());
     petBusinessTypeDTO.setDescription(petBusinessType.getDescription());
     return petBusinessTypeDTO;
   }

--- a/src/main/java/com/petservice/main/business/database/repository/PetBusinessTypeRepository.java
+++ b/src/main/java/com/petservice/main/business/database/repository/PetBusinessTypeRepository.java
@@ -9,4 +9,5 @@ public interface PetBusinessTypeRepository extends JpaRepository<PetBusinessType
 
   boolean existsByTypeName(String typeName);
 
+  boolean existsByTypeCode(String typeCode);
 }

--- a/src/main/java/com/petservice/main/business/service/PetBusinessTypeService.java
+++ b/src/main/java/com/petservice/main/business/service/PetBusinessTypeService.java
@@ -37,7 +37,8 @@ public class PetBusinessTypeService implements PetBusinessTypeServiceInterface {
 
       petBusinessType.setTypeName(petBusinessTypeDTO.getTypeName());
       petBusinessType.setDescription(petBusinessTypeDTO.getDescription());
-
+      petBusinessType.setSectorCode(petBusinessTypeDTO.getSectorCode());
+      petBusinessType.setTypeCode(petBusinessTypeDTO.getTypeCode());
       return petBusinessTypeMapper.toBasicDTO(petBusinessTypeRepository.save(petBusinessType));
 
     }catch (Exception e){
@@ -124,11 +125,14 @@ public class PetBusinessTypeService implements PetBusinessTypeServiceInterface {
   @Override
   public boolean insertValidationType(PetBusinessTypeDTO petBusinessTypeDTO){
 
-    if(isBlank(petBusinessTypeDTO.getTypeName()) || isBlank(petBusinessTypeDTO.getDescription())){
+    if(isBlank(petBusinessTypeDTO.getTypeName())
+      || isBlank(petBusinessTypeDTO.getDescription())
+      || isBlank(petBusinessTypeDTO.getSectorCode())
+      || isBlank(petBusinessTypeDTO.getTypeCode())){
       return false;
     }
 
-    if(petBusinessTypeRepository.existsByTypeName(petBusinessTypeDTO.getTypeName())){
+    if(petBusinessTypeRepository.existsByTypeCode(petBusinessTypeDTO.getTypeCode())){
       return false;
     }
 
@@ -144,12 +148,16 @@ public class PetBusinessTypeService implements PetBusinessTypeServiceInterface {
     }
 
     if( isBlank(petBusinessTypeDTO.getTypeName())
-        || isBlank(petBusinessTypeDTO.getDescription())){
+        || isBlank(petBusinessTypeDTO.getDescription())
+        || isBlank(petBusinessTypeDTO.getSectorCode())
+        || isBlank(petBusinessTypeDTO.getTypeCode())){
       return false;
     }
 
     if(petBusinessType.getTypeName().equals(petBusinessTypeDTO.getTypeName())
-        && petBusinessType.getDescription().equals(petBusinessTypeDTO.getDescription())) {
+        && petBusinessType.getDescription().equals(petBusinessTypeDTO.getDescription())
+        && petBusinessType.getSectorCode().equals(petBusinessTypeDTO.getSectorCode())
+        && petBusinessType.getTypeCode().equals(petBusinessTypeDTO.getTypeCode())) {
       return false;
     }
 


### PR DESCRIPTION
## 설명

백엔드: 실제 사업자 api에서 제공되는 섹터 타입과 분류 코드에 맞게 사업자 타입의 entity, dto, mapper, service 코드 수정 
프론트 엔드: 사업자 타입 관련 컴포넌트 작성(타입, 타입 리스트, 타입 관리 리스트, 타입 삭제 버튼, 타입 수정 폼, 타입  등록 폼)(페이지 남음)

## 작성 타입
- [x] 버그 수정
- [x] 새로운 기능 추가
- [ ] 설명 수정
- [x] 코드 리팩토링(경로 변경, 성능 최적화)

## 체크사항
- [ ] 내가 작성한 코드를 직접 테스트를 하였습니다.
- [x] 내가 작성한 코드에 대해서 주변에 미치는 영향을 최소화 하였습니다.
- [x] 깔끔히 코드를 작성 하였으며, 프로젝트 내 테스트 경로 외의 테스트 코드를 모두 지운 것을 확인하였습니다.
- [x] 코드가 이해하기 쉽게 작성되었는지 확인하였습니다.
- [x] 코드 내 민감한 정보가 없는 것을 확인하였습니다.
- [ ] 하드코딩을 모두 지운 것을 확인하였습니다.

## 특이 사항
코드 작성하면서 문제되는 부분이나, 불편한 점에 대해 적어주세요!!
